### PR TITLE
Test fixes

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,6 @@ fixtures:
   repositories:
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "2.0.x"
+      ref: "db9daeb1831930f648b99e1867867ba6a071e68a"
   symlinks:
     unattended_upgrades: "#{source_dir}"

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -12,12 +12,21 @@ describe 'unattended_upgrades' do
 
   it { should contain_package("unattended-upgrades") }
 
+  it { should contain_apt__conf('unattended-upgrades').with({
+      "require" => "Package[unattended-upgrades]",
+  })
+  }
+
+  it { should contain_apt__conf('periodic').with({
+      "require" => "Package[unattended-upgrades]",
+  })
+  }
+
   it {
     should create_file(file_unattended).with({
       "owner"   => "root",
       "group"   => "root",
       "mode"    => "0644",
-      "require" => "Package[unattended-upgrades]",
     })
   }
 
@@ -26,7 +35,6 @@ describe 'unattended_upgrades' do
       "owner"   => "root",
       "group"   => "root",
       "mode"    => "0644",
-      "require" => "Package[unattended-upgrades]",
     })
   }
 end


### PR DESCRIPTION
puppetlabs_spec_helper doesn't allow pinning to a branch instead of a
tag/ref, and the requires are in the apt_conf not on the files.