### PR TITLE
travis: Test only latest Ruby and Puppet.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,11 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
+    - rvm: 2.1.6
+      env: PUPPET_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
+    - rvm: 2.1.6
+      env: PUPPET_VERSION="~> 4.0" ORDERING="random"
+  allow_failures:
+    - env: PUPPET_VERSION="~> 4.0" ORDERING="random"
 notifications:
   email: false


### PR DESCRIPTION
Since this module contains no Ruby code there's really no point in running a matrix for all Ruby versions. We trust Puppet to work on the different Ruby versions so all we need is to run the different versions of Puppet.

We use Ruby 2.1.6 since 2.2.x causes Puppet 3 and 4 to crash.
