### PR TITLE
unattended-upgrades are broken on Ubuntu by default due to origins typo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,8 +39,8 @@ class unattended_upgrades::params {
     }
     'ubuntu': {
       $legacy_origin = true
-      $origins       = ['${distro_id} {$distro_codename}-security', #lint:ignore:single_quote_string_with_variables
-                        '${distro_id} {$distro_codename}-updates',] #lint:ignore:single_quote_string_with_variables
+      $origins       = ['${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+                        '${distro_id} ${distro_codename}-updates',] #lint:ignore:single_quote_string_with_variables
     }
     default: {
       fail('Please explicitly specify unattended_upgrades::legacy_origin and unattended_upgrades::origins')

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -96,7 +96,7 @@ describe 'unattended_upgrades' do
     let(:facts) { {
       :osfamily => 'Debian',
       :lsbdistid => 'Ubuntu',
-      :lsbistcodename => 'truste',
+      :lsbistcodename => 'trusty',
       :lsbrelease => '14.04',
     } }
     it {

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -105,8 +105,11 @@ describe 'unattended_upgrades' do
         'group'   => 'root',
         'mode'    => '0644',
       }).with_content(
-        # This is the only line that's different for Ubuntu compared to Debian
-        /Unattended-Upgrade::Allowed-Origins {/
+        # This is the only section that's different for Ubuntu compared to Debian
+        /\Unattended-Upgrade::Allowed-Origins\ {\n
+        \t"\${distro_id}\ \${distro_codename}-security";\n
+        \t"\${distro_id}\ \${distro_codename}-updates";\n
+        };/x
       )}
   end
 


### PR DESCRIPTION
There is a typo in the default origins parameter for Ubuntu (the leading
dollar sign and brace for the 'distro_codename' fields are transposed).  This
causes all unattended-upgrades to be disabled on Ubuntu machines by default.