### PR TITLE
Support for Raspbian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class unattended_upgrades::params {
   }
 
   case $xfacts['lsbdistid'] {
-    'debian': {
+    'debian', 'raspbian': {
       case $xfacts['lsbdistcodename'] {
         'squeeze': {
           $legacy_origin = true

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -110,6 +110,22 @@ describe 'unattended_upgrades' do
       )}
   end
 
+  context 'with defaults on Raspbian' do
+    let(:facts) { {
+      :osfamily => 'Debian',
+      :lsbdistid => 'Raspbian',
+      :lsbistcodename => 'jessie',
+      :lsbrelease => '8.0',
+    } }
+    it {
+      should create_file(file_unattended).with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+      })
+    }
+  end
+
   context 'set all the things' do
     let :params do
       {


### PR DESCRIPTION
Facter returns 'Raspbian' for lsbdistid on Raspbian 8 now.

```
lsbdistcodename => jessie
lsbdistdescription => Raspbian GNU/Linux 8.0 (jessie)
lsbdistid => Raspbian
lsbdistrelease => 8.0
lsbmajdistrelease => 8
```
Puppet fails on a Raspbian 8 host because Raspbian is not included in the case statement.