### PR TITLE
Include variable "RandomSleep".

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,8 +38,8 @@ class unattended_upgrades (
   validate_hash($age)
   $_age = merge($::unattended_upgrades::default_age, $age)
   validate_integer(
-    $size,
     $random_sleep,
+    $size,
   )
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class unattended_upgrades (
   $minimal_steps        = true,
   $origins              = $::unattended_upgrades::params::origins,
   $package_ensure       = installed,
+  $random_sleep         = 1800,
   $size                 = 0,
   $update               = 1,
   $upgrade              = 1,
@@ -36,7 +37,10 @@ class unattended_upgrades (
   $_backup = merge($::unattended_upgrades::default_backup, $backup)
   validate_hash($age)
   $_age = merge($::unattended_upgrades::default_age, $age)
-  validate_integer($size)
+  validate_integer(
+    $size,
+    $random_sleep,
+  )
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,10 +37,8 @@ class unattended_upgrades (
   $_backup = merge($::unattended_upgrades::default_backup, $backup)
   validate_hash($age)
   $_age = merge($::unattended_upgrades::default_age, $age)
-  validate_integer(
-    $random_sleep,
-    $size,
-  )
+  validate_integer($random_sleep)
+  validate_integer($size)
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)
 

--- a/templates/periodic.erb
+++ b/templates/periodic.erb
@@ -46,3 +46,15 @@ APT::Periodic::Verbose "<%= @verbose %>";
 #      1:  progress report       (actually any string)
 #      2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
 #      3:  + trace on
+#
+APT::Periodic::RandomSleep "<%= @random_sleep %>";
+#  - The apt cron job will delay its execution by a random
+#    time span between zero and 'APT::Periodic::RandomSleep'
+#    seconds.
+#    This is done because otherwise everyone would access the
+#    mirror servers at the same time and put them collectively
+#    under very high strain.
+#    You can set this to '0' if you are using a local mirror and
+#    do not care about the load spikes.
+#    Note that sleeping in the apt job will be delaying the
+#    execution of all subsequent cron.daily jobs.


### PR DESCRIPTION
The apt cron job will delay its execution by a random time span between zero and 'APT::Periodic::RandomSleep' seconds.