### PR TITLE
Include 'APT::Periodic::RandomSleep'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Using unattended\_upgrades simply consists of including the module and if needed
 * `minimal_steps` (`true`): Split the upgrade process into sections to allow shutdown during upgrade.
 * `origins`: The repositories from which to automatically upgrade included packages.
 * `package_ensure` (`installed`): The ensure state for the 'unattended-upgrades' package.
+* `random_sleep` (`300`): Seconds of delay on the cron job execution.
 * `size` (`0`): Maximum size of the cache in MB.
 * `update` (`1`): Do "apt-get update" automatically every n-days.
 * `upgrade` (`1`): Run the "unattended-upgrade" security upgrade script every n-days.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class unattended_upgrades (
   $minimal_steps        = true,
   $origins              = $::unattended_upgrades::params::origins,
   $package_ensure       = installed,
+  $random_sleep         = 1800,
   $size                 = 0,
   $update               = 1,
   $upgrade              = 1,
@@ -36,6 +37,7 @@ class unattended_upgrades (
   $_backup = merge($::unattended_upgrades::default_backup, $backup)
   validate_hash($age)
   $_age = merge($::unattended_upgrades::default_age, $age)
+  validate_integer($random_sleep)
   validate_integer($size)
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@ class unattended_upgrades (
   $minimal_steps        = true,
   $origins              = $::unattended_upgrades::params::origins,
   $package_ensure       = installed,
-  $random_sleep         = 1800,
+  $random_sleep         = undef,
   $size                 = 0,
   $update               = 1,
   $upgrade              = 1,
@@ -37,7 +37,6 @@ class unattended_upgrades (
   $_backup = merge($::unattended_upgrades::default_backup, $backup)
   validate_hash($age)
   $_age = merge($::unattended_upgrades::default_age, $age)
-  validate_integer($random_sleep)
   validate_integer($size)
   validate_hash($upgradeable_packages)
   $_upgradeable_packages = merge($::unattended_upgrades::default_upgradeable_packages, $upgradeable_packages)

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -385,17 +385,5 @@ describe 'unattended_upgrades' do
         }.to raise_error(Puppet::Error, /not a boolean/)
       end
     end
-    context 'bad random_sleep' do
-      let :params do
-        {
-          :random_sleep => 'foo',
-        }
-      end
-      it do
-        expect {
-	  subject.call
-	 }.to raise_error(Puppet::Error, /to be an Integer/)
-      end
-    end
   end
 end

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -83,6 +83,8 @@ describe 'unattended_upgrades' do
         /APT::Periodic::AutocleanInterval "0";/
       ).with_content(
         /APT::Periodic::Verbose "0";/
+      ).with_content(
+	/APT::Periodic::RandomSleep "1800";/
       )
     }
 
@@ -154,6 +156,7 @@ describe 'unattended_upgrades' do
           'only_on_error' => true,
         },
         :dl_limit             => 70,
+	 :random_sleep         => 1800,
       }
     end
     it { should contain_package('unattended-upgrades') }
@@ -225,6 +228,8 @@ describe 'unattended_upgrades' do
         /APT::Periodic::AutocleanInterval "5";/
       ).with_content(
         /APT::Periodic::Verbose "1";/
+      ).with_content(
+	/APT::Periodic::RandomSleep "1800";/
       )
     }
 
@@ -378,6 +383,18 @@ describe 'unattended_upgrades' do
         expect {
           subject.call
         }.to raise_error(Puppet::Error, /not a boolean/)
+      end
+    end
+    context 'bad random_sleep' do
+      let :params do
+        {
+          :random_sleep => 'foo',
+        }
+      end
+      it do
+        expect {
+	  subject.call
+	 }.to raise_error(Puppet::Error, /to be an Integer/)
       end
     end
   end

--- a/templates/periodic.erb
+++ b/templates/periodic.erb
@@ -46,6 +46,7 @@ APT::Periodic::Verbose "<%= @verbose %>";
 #      1:  progress report       (actually any string)
 #      2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
 #      3:  + trace on
+<%- unless @random_sleep.nil? -%>
 #
 APT::Periodic::RandomSleep "<%= @random_sleep %>";
 #  - The apt cron job will delay its execution by a random
@@ -58,3 +59,4 @@ APT::Periodic::RandomSleep "<%= @random_sleep %>";
 #    do not care about the load spikes.
 #    Note that sleeping in the apt job will be delaying the
 #    execution of all subsequent cron.daily jobs.
+<%- end -%>

--- a/templates/periodic.erb
+++ b/templates/periodic.erb
@@ -46,3 +46,15 @@ APT::Periodic::Verbose "<%= @verbose %>";
 #      1:  progress report       (actually any string)
 #      2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
 #      3:  + trace on
+#
+APT::Periodic::RandomSleep "<%= @random_sleep %>";
+#  - The apt cron job will delay its execution by a random
+#    time span between zero and 'APT::Periodic::RandomSleep'
+#    seconds.
+#    This is done because otherwise everyone would access the
+#    mirror servers at the same time and put them collectively
+#    under very high strain.
+#    You can set this to '0' if you are using a local mirror and
+#    do not care about the load spikes.
+#    Note that sleeping in the apt job will be delaying the
+#    execution of all subsequent cron.daily jobs.


### PR DESCRIPTION
When the apt job starts, it will sleep for a random period between 0 and
APT::Periodic::RandomSleep seconds. The default value is "1800" so that
the script will stall for up to 30 minutes (1800 seconds) so that the
mirror servers are not crushed by everyone running their updates all at
the same time. Only set this to 0 if you use a local mirror and don't
mind the load spikes. Note that while the apt job is sleeping it will
cause the execution of the rest of your cron.daily jobs to be delayed.