### PR TITLE
Corrected a typo to fix issue #22

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,8 +48,8 @@ class unattended_upgrades::params {
     }
     'ubuntu': {
       $legacy_origin = true
-      $origins       = ['${distro_id} {$distro_codename}-security', #lint:ignore:single_quote_string_with_variables
-                        '${distro_id} {$distro_codename}-updates',] #lint:ignore:single_quote_string_with_variables
+      $origins       = ['${distro_id} ${distro_codename}-security', #lint:ignore:single_quote_string_with_variables
+                        '${distro_id} ${distro_codename}-updates',] #lint:ignore:single_quote_string_with_variables
     }
     default: {
       fail('Please explicitly specify unattended_upgrades::legacy_origin and unattended_upgrades::origins')


### PR DESCRIPTION
Before this fix, `puppet-unattended_upgrades` would create the invalid syntax

    # /etc/apt/apt.conf.d/50unattended-upgrades
    Unattended-Upgrade::Allowed-Origins {
            "${distro_id} {$distro_codename}-security";
            "${distro_id} {$distro_codename}-updates";
    };

This fix corrects the invalid `{$distro_codename}` to valid `${distro_codename}`:

    # /etc/apt/apt.conf.d/50unattended-upgrades
    Unattended-Upgrade::Allowed-Origins {
            "${distro_id} ${distro_codename}-security";
            "${distro_id} ${distro_codename}-updates";
    };