### PR TITLE
Add optional notify_update parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,7 @@ class unattended_upgrades (
   $upgrade              = 1,
   $upgradeable_packages = {},
   $verbose              = 0,
+  $notify_update        = undef,
 ) inherits ::unattended_upgrades::params {
 
   validate_bool(
@@ -45,21 +46,24 @@ class unattended_upgrades (
   }
 
   apt::conf { 'unattended-upgrades':
-    priority => 50,
-    content  => template("${module_name}/unattended-upgrades.erb"),
-    require  => Package['unattended-upgrades'],
+    priority      => 50,
+    content       => template("${module_name}/unattended-upgrades.erb"),
+    require       => Package['unattended-upgrades'],
+    notify_update => $notify_update,
   }
 
   apt::conf { 'periodic':
-    priority => 10,
-    content  => template("${module_name}/periodic.erb"),
-    require  => Package['unattended-upgrades'],
+    priority      => 10,
+    content       => template("${module_name}/periodic.erb"),
+    require       => Package['unattended-upgrades'],
+    notify_update => $notify_update,
   }
 
   apt::conf { 'auto-upgrades':
-    ensure   => absent,
-    priority => 20,
-    require  => Package['unattended-upgrades'],
+    ensure        => absent,
+    priority      => 20,
+    require       => Package['unattended-upgrades'],
+    notify_update => $notify_update,
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -36,6 +36,6 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"puppetlabs/apt","version_requirement":">= 2.0.0 < 3.0.0"}
+    {"name":"puppetlabs/apt","version_requirement":">= 2.2.0 < 3.0.0"}
   ]
 }


### PR DESCRIPTION
In our environment we make sure apt_update is ran before any packages is installed with the following:
Exec['apt_update'] -> Package <| |>

With this statement, a dependency cycle is created:
(Exec[apt_update] => Package[unattended-upgrades] => Apt::Conf[unattended-upgrades] => Apt::Setting[conf-unattended-upgrades] => File[/etc/apt/apt.conf.d/50unattended-upgrades] => Class[Apt::Update] => Exec[apt_update])

It's possible to call apt::conf (v2.2.0 or later) and not run apt_update by specifying 'notify_update => false'. This avoids our dependency problem.

This PR adds an optional parameter 'notify_update' to init.pp (if the parameter is not specified, the defaults applies and apt_update is notified). The parameter can be undef (default), true or false.
