### PR TITLE
Include variable 'RandomSleep'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Using unattended\_upgrades simply consists of including the module and if needed
 * `minimal_steps` (`true`): Split the upgrade process into sections to allow shutdown during upgrade.
 * `origins`: The repositories from which to automatically upgrade included packages.
 * `package_ensure` (`installed`): The ensure state for the 'unattended-upgrades' package.
+* `random_sleep` (`300`): Seconds of delay on the cron job execution.
 * `size` (`0`): Maximum size of the cache in MB.
 * `update` (`1`): Do "apt-get update" automatically every n-days.
 * `upgrade` (`1`): Run the "unattended-upgrade" security upgrade script every n-days.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class unattended_upgrades (
   $minimal_steps        = true,
   $origins              = $::unattended_upgrades::params::origins,
   $package_ensure       = installed,
+  $random_sleep         = undef,
   $size                 = 0,
   $update               = 1,
   $upgrade              = 1,

--- a/spec/classes/unattended_upgrades_spec.rb
+++ b/spec/classes/unattended_upgrades_spec.rb
@@ -279,6 +279,7 @@ describe 'unattended_upgrades' do
           'only_on_error' => true,
         },
         :dl_limit             => 70,
+        :random_sleep         => 300,
       }
     end
     it { should contain_package('unattended-upgrades') }
@@ -350,6 +351,8 @@ describe 'unattended_upgrades' do
         /APT::Periodic::AutocleanInterval "5";/
       ).with_content(
         /APT::Periodic::Verbose "1";/
+      ).with_content(
+        /APT::Periodic::RandomSleep "300";/
       )
     }
 

--- a/templates/periodic.erb
+++ b/templates/periodic.erb
@@ -46,3 +46,17 @@ APT::Periodic::Verbose "<%= @verbose %>";
 #      1:  progress report       (actually any string)
 #      2:  + command outputs     (remove -qq, remove 2>/dev/null, add -d)
 #      3:  + trace on
+<%- unless @random_sleep.nil? -%>
+#
+APT::Periodic::RandomSleep "<%= @random_sleep %>";
+#  - The apt cron job will delay its execution by a random
+#    time span between zero and 'APT::Periodic::RandomSleep'
+#    seconds.
+#    This is done because otherwise everyone would access the
+#    mirror servers at the same time and put them collectively
+#    under very high strain.
+#    You can set this to '0' if you are using a local mirror and
+#    do not care about the load spikes.
+#    Note that sleeping in the apt job will be delaying the
+#    execution of all subsequent cron.daily jobs.
+<%- end -%>


### PR DESCRIPTION
When the apt job starts, it will sleep for a random period between 0 and
APT::Periodic::RandomSleep seconds. The default value is "1800" so that
the script will stall for up to 30 minutes (1800 seconds) so that the
mirror servers are not crushed by everyone running their updates all at
the same time. Only set this to 0 if you use a local mirror and don't
mind the load spikes. Note that while the apt job is sleeping it will
cause the execution of the rest of your cron.daily jobs to be delayed.